### PR TITLE
fix(style): heti squeezes cjk punctuation too much

### DIFF
--- a/src/components/ChineseExtraHead.astro
+++ b/src/components/ChineseExtraHead.astro
@@ -1,5 +1,5 @@
 <style is:global>
-  // The full css resets too much style, so I just took the spacing part from https://github.com/sivan/heti/blob/master/lib/helpers/_add-on.scss
+  /* The full css resets too much style, so I just took the spacing part from https://github.com/sivan/heti/blob/master/lib/helpers/_add-on.scss */
   heti-spacing {
     display: inline;
   }
@@ -15,6 +15,7 @@
   }
   heti-adjacent {
     display: inline;
+    text-spacing-trim: space-all;
   }
   .heti-adjacent-half {
     margin-inline-end: -0.5em;


### PR DESCRIPTION
This bug only exists on Chromium-based browsers, Firefox is safe.

see: https://github.com/sivan/heti/issues/124, https://github.com/sivan/heti/commit/5b870bae0dbae3a7d5e8b369295bd64fd5728d3f